### PR TITLE
Avoid 1:0 when it should be a sequence of length 0

### DIFF
--- a/R/normalizeByDoi.R
+++ b/R/normalizeByDoi.R
@@ -54,10 +54,10 @@ normalizeByDoi <- function(dataframe,doi='doi',year='ano.do.artigo',issn='issn',
     a %>>% mutate_if(is.factor,as.character) %>>% (. -> a)
 
     # no[DOI,Revista,ISSN,Ano]
-    a[ is.na(a$doi) | a$doi=='' , 'doi'] <- paste0('noDOI_',1:nrow(a[ is.na(a$doi) | a$doi=='', 'doi']))
-    a[ is.na(a$revista) | a$revista=='' , 'revista'] <- paste0('noRevsita_',1:nrow(a[ is.na(a$revista) | a$revista=='', 'revista']))
-    a[ is.na(a$issn) | a$issn=='' , 'issn'] <- paste0('noISSN_',1:nrow(a[ is.na(a$issn) | a$issn=='', 'issn']))
-    a[ is.na(a$ano) | a$ano=='' , 'issn'] <- paste0('noAno_',1:nrow(a[ is.na(a$ano) | a$ano=='', 'ano']))
+    a[ is.na(a$doi) | a$doi=='' , 'doi'] <- paste0('noDOI_',seq_len(sum(is.na(a$doi) | a$doi=='')))
+    a[ is.na(a$revista) | a$revista=='' , 'revista'] <- paste0('noRevsita_',seq_len(is.na(a$revista) | a$revista=='')))
+    a[ is.na(a$issn) | a$issn=='' , 'issn'] <- paste0('noISSN_',seq_len(sum(is.na(a$issn) | a$issn=='')))
+    a[ is.na(a$ano) | a$ano=='' , 'issn'] <- paste0('noAno_',seq_len(sum(is.na(a$ano) | a$ano=='')))
 
     a %>>%
         dplyr::group_by(doi) %>>%

--- a/R/normalizeByDoi.R
+++ b/R/normalizeByDoi.R
@@ -55,7 +55,7 @@ normalizeByDoi <- function(dataframe,doi='doi',year='ano.do.artigo',issn='issn',
 
     # no[DOI,Revista,ISSN,Ano]
     a[ is.na(a$doi) | a$doi=='' , 'doi'] <- paste0('noDOI_',seq_len(sum(is.na(a$doi) | a$doi=='')))
-    a[ is.na(a$revista) | a$revista=='' , 'revista'] <- paste0('noRevsita_',seq_len(is.na(a$revista) | a$revista=='')))
+    a[ is.na(a$revista) | a$revista=='' , 'revista'] <- paste0('noRevsita_',seq_len(sum(is.na(a$revista) | a$revista=='')))
     a[ is.na(a$issn) | a$issn=='' , 'issn'] <- paste0('noISSN_',seq_len(sum(is.na(a$issn) | a$issn=='')))
     a[ is.na(a$ano) | a$ano=='' , 'issn'] <- paste0('noAno_',seq_len(sum(is.na(a$ano) | a$ano=='')))
 


### PR DESCRIPTION
Fixes errors seen with tibble 3.1.0, which is stricter with assignments of the form `a[FALSE, 'column'] <- ...` .